### PR TITLE
chore: fix release workflow on github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: ci
+name: release
 
 on:
   workflow_dispatch:
@@ -12,7 +12,6 @@ jobs:
   release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    needs: check
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
remove the wrong configuration, the field "needs" from release workflow on github